### PR TITLE
[ci skip] adding user @rockdoc-mo

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,3 @@
 * @rockdoc
 * @ehogan
+* @rockdoc-mo

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,5 +42,6 @@ about:
     produced by the UK Met Office's Unified Model.
 extra:
   recipe-maintainers:
+    - rockdoc-mo
     - ehogan
     - rockdoc


### PR DESCRIPTION

Hi! This is the friendly automated conda-forge-webservice.

I've added user @rockdoc-mo as instructed in #4.

Merge this PR to add the user. Please do not rerender this PR or change it in any way. It has `[ci skip]` in the commit message to avoid pushing a new build and so the build configuration in the feedstock should not be changed.

Fixes #4